### PR TITLE
DB Connection improvement and fix to ready listener

### DIFF
--- a/Modules/Bot.ts
+++ b/Modules/Bot.ts
@@ -12,7 +12,7 @@ export const bot = new CommandClient(config.token, {}, commandOptions);
 
 bot.connect();
 
-bot.on('ready', () => {
+bot.once('ready', () => {
     console.log('[startup] Bot ready.');
 });
 

--- a/master.ts
+++ b/master.ts
@@ -4,12 +4,15 @@ const port: number = 3001;
 
 console.log('--------------------\nStarting moustache\n--------------------');
 
-try {
-    mongoose.connect('mongodb://localhost/moustacheDB', { useNewUrlParser: true });
-    console.log('[master] Connected to MongoDB.');
-} catch (e) {
-    console.log(e);
-}
+
+    mongoose.connect('mongodb://localhost:27017/moustacheDB', { 
+        useNewUrlParser: true,
+        useCreateIndex: true,
+        autoReconnect: true, 
+    })
+        .then(() => console.log('[master] Connected to MongoDB.'))
+        .catch(console.log)
+
 
 app.listen(port, () => {
     console.log(`[express] Listening at port ${port}`);

--- a/master.ts
+++ b/master.ts
@@ -5,13 +5,13 @@ const port: number = 3001;
 console.log('--------------------\nStarting moustache\n--------------------');
 
 
-    mongoose.connect('mongodb://localhost:27017/moustacheDB', { 
-        useNewUrlParser: true,
-        useCreateIndex: true,
-        autoReconnect: true, 
-    })
-        .then(() => console.log('[master] Connected to MongoDB.'))
-        .catch(console.log)
+mongoose.connect('mongodb://localhost:27017/moustacheDB', { 
+    useNewUrlParser: true,
+    useCreateIndex: true,
+    autoReconnect: true, 
+})
+    .then(() => console.log('[master] Connected to MongoDB.'))
+    .catch(console.log)
 
 
 app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "moustacheos",
   "version": "XP 1.1",
   "description": "",
-  "main": "master.js",
+  "main": "master.ts",
   "scripts": {
     "compile": "tsc",
     "start": "node ./build/master.js",
+    "pm2start": "pm2 start ./build/master.js",
     "pm2restart": "pm2 restart ./build/master.js"
   },
   "author": "",


### PR DESCRIPTION
This PR
  - add a port in `mongoose.connect()` connection string (`useNewUrlParser`).
  - add `useCreateIndex` to fix depreciation warning.
  - add `autoReconnect`.
  - use .then/.catch to handle mongoose connection since `mongoose.connect()` returns a Promise.
  - change the ready listener to `.once` instead of `.on`.
  - add a `pm2start` script to deploy easily